### PR TITLE
Simplify SSR

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,20 +1,12 @@
 import React from "react";
 import { HeadProvider } from "react-head";
-import { renderToString } from "react-dom/server";
 
-let collectHeadTags = [];
-
-export const replaceRenderer = ({ bodyComponent, replaceBodyHTMLString }) => {
-  const headTags = [];
-  collectHeadTags = headTags;
-
-  const bodyHTML = renderToString(
-    <HeadProvider headTags={headTags}>{bodyComponent}</HeadProvider>
-  );
-
-  replaceBodyHTMLString(bodyHTML);
-};
+let headTags = [];
 
 export const onRenderBody = ({ setHeadComponents }) => {
-  setHeadComponents(collectHeadTags);
+  setHeadComponents(headTags);
+};
+
+export const wrapRootElement = ({ element }) => {
+  return <HeadProvider headTags={headTags}>{element}</HeadProvider>;
 };


### PR DESCRIPTION
`replaceRenderer` is not needed, `wrapRootElement` can be used instead to add `<HeadProvider />`